### PR TITLE
Add composer/installers to fix installation path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "type": "cakephp-plugin",
     "require": {
         "aws/aws-sdk-php": "~3.0",
-        "cakephp/cakephp": "~2.6"
+        "cakephp/cakephp": "~2.6",
+        "composer/installers": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "~3.7"


### PR DESCRIPTION
If composer/installers is not loaded in as a dependency when this library is installed, it will be placed into the vendor directory instead of the plugin directory.